### PR TITLE
Fix/doculinks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,7 +126,7 @@ const config = {
               },
               {
                 label: 'Support',
-                to: 'https://sensebox.de/support',
+                to: 'https://sensebox.de/de/contact',
               },
             ],
           },

--- a/static/_redirects
+++ b/static/_redirects
@@ -39,6 +39,7 @@
 /blockly/blockly-display/ /docs/hardware/accessoires/display
 /blockly/blockly-web-lora/ /docs/editors/blockly/blocks/lora
 /blockly/blockly-web-wifi/ /docs/editors/blockly/blocks/web/wifi
+/blockly/blockly-erster-sketch/ /docs/boards/mcu/mcu-erster-sketch
 
 # misc
 


### PR DESCRIPTION
- Redirected the now non-existing site "/blockly/blockly-erster-sketch/" to "/docs/boards/mcu/mcu-erster-sketch"
- Changed the now non-existing site "https://sensebox.de/support" to "https://sensebox.de/de/contact"